### PR TITLE
Coordinate placeholders

### DIFF
--- a/src/main/java/io/github/dediamondpro/xcatch/listeners/OnBlockBreak.java
+++ b/src/main/java/io/github/dediamondpro/xcatch/listeners/OnBlockBreak.java
@@ -78,6 +78,9 @@ public class OnBlockBreak implements Listener {
                     put("{flags}", String.valueOf(flags.get(uuid).flags));
                     put("{ore}", ore);
                     put("{amount}", String.valueOf(amountMined));
+                    put("{x}", String.valueOf((int)event.getPlayer().getLocation().getX()));
+                    put("{y}", String.valueOf((int)event.getPlayer().getLocation().getY()));
+                    put("{z}", String.valueOf((int)event.getPlayer().getLocation().getZ()));
                 }};
                 if (XCatch.config.getInt("ban-flags") != 0 && flags.get(uuid).flags >= XCatch.config.getInt("ban-flags")
                         && !event.getPlayer().hasPermission("xcatch.noban")) {


### PR DESCRIPTION
Get the coordinate as placeholders. Useful when sending location to Discord so that staff can check later if none are online.